### PR TITLE
Release 0.13.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # CURRENTLY-IN-DEVELOPMENT
+# `v0.13.0.0`
+##### Released by codydouglasBC on Jul 23, 2024 @ 10:32 PM UTC
 ### New Controllers
   - ESXi Controllers
     - 105 - firewall_default_action_incoming
@@ -17,6 +19,8 @@
 ### Controller Enhancements
   - VCSA control 1234 - continue remediation when hitting error on one VM.
   - SDDC Manager control 1604 - remove host and port parameters.
+### Dependency Version Changes
+  - urllib3 pinned to 1.26.19
 # Initial Open Source Release!
 - Support for two controller types (Compliance and Configuration)
   - Compliance has support for 5 products and 77 Controllers

--- a/config_modules_vmware/__init__.py
+++ b/config_modules_vmware/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Broadcom. All Rights Reserved.
 
-version: str = "0.1.0.0"
+version: str = "0.13.0.0"
 name: str = "config_modules_vmware"
 author: str = "Broadcom"
 description: str = "VMware Unified Config Modules"

--- a/devops/release/library/version.yml
+++ b/devops/release/library/version.yml
@@ -1,4 +1,4 @@
-user-id: codyd
+user-id: codydouglasBC
 
-version:  0.1.0.0
+version:  0.13.0.0
 

--- a/requirements/functional-test-requirements.txt
+++ b/requirements/functional-test-requirements.txt
@@ -13,5 +13,4 @@ paramiko~=3.4.0
 
 scp~=0.15.0
 
-urllib3~=2.2.1; python_version>="3.8"
-urllib3~=2.0.7; python_version<="3.7"
+urllib3~=1.26.19

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -11,3 +11,6 @@ lxml~=5.2.2
 #jsonschema~=4.22.0; python_version>="3.8"
 #jsonschema~=4.17.3; python_version<="3.7"
 jsonschema~=4.17.3
+
+#some VCF release doesn't have the updated ssl lib required by Urllib3 2.0.x. Urllib3 1.26.19 is validated to work properly
+urllib3~=1.26.19

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def _parse_requirements(requirements_file):
 setup(
     name=config_modules_vmware.name,
     # duplicate information due to concourse pipeline requirement
-    version="0.1.0.0",
+    version="0.13.0.0",
     description=config_modules_vmware.description,
     author=config_modules_vmware.author,
     install_requires=_parse_requirements("requirements/prod-requirements.txt"),


### PR DESCRIPTION
Changing the version number to start at 13 to match our current internal drop number for easier tracking.
Also pin the version of urllib3 dependency for compatibility with what is available on VCF.