### PR TITLE
Patch release 0.13.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CURRENTLY-IN-DEVELOPMENT
+# `v0.13.2.0`
+##### Released by ravi-pratap-s on Jul 30, 2024 @ 08:42 PM UTC
+### Dependency Version Changes
+  - pyVmomi version downgraded to 7.0.3 inline with salt-ext dependency.
 # `v0.13.1.0`
 ##### Released by codydouglasBC on Jul 24, 2024 @ 10:56 PM UTC
 ### Bug Fixes

--- a/config_modules_vmware/__init__.py
+++ b/config_modules_vmware/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Broadcom. All Rights Reserved.
 
-version: str = "0.13.1.0"
+version: str = "0.13.2.0"
 name: str = "config_modules_vmware"
 author: str = "Broadcom"
 description: str = "VMware Unified Config Modules"

--- a/devops/release/library/version.yml
+++ b/devops/release/library/version.yml
@@ -1,4 +1,4 @@
-user-id: codydouglasBC
+user-id: ravi-pratap-s
 
-version:  0.13.1.0
+version:  0.13.2.0
 

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -1,4 +1,4 @@
-pyVmomi~=8.0.2.0.1
+pyVmomi==7.0.3
 
 requests~=2.32.2; python_version>="3.8"
 requests~=2.31.0; python_version<="3.7"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def _parse_requirements(requirements_file):
 setup(
     name=config_modules_vmware.name,
     # duplicate information due to concourse pipeline requirement
-    version="0.13.1.0",
+    version="0.13.2.0",
     description=config_modules_vmware.description,
     author=config_modules_vmware.author,
     install_requires=_parse_requirements("requirements/prod-requirements.txt"),


### PR DESCRIPTION
Downgrade pyvmomi version to 7.0.3 to match salt-ext dependency. 