### PR TITLE
Update requirements to comply with Salt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # CURRENTLY-IN-DEVELOPMENT
+# `v0.14.6.0`
+##### Released by codydouglasBC on Sept 05, 2024 @ 11:07 PM UTC
+### Dependency Version Changes
+- lxml version requirement changed to "lxml>=4.9.1,<=5.2.2"
+- requests version requirement changed to "requests>=2.31.0"
+- pyOpenSSL version requirement changed to "pyOpenSSL>=23.2.0,<=24.0.0"
+- urllib3 version requirement changed to "urllib3>=1.26.6,<2.0.0"
 # `v0.14.0.0`
 ##### Released by ravi-pratap-s on Aug 09, 2024 @ 06:33 PM UTC
 ### New Controllers

--- a/config_modules_vmware/__init__.py
+++ b/config_modules_vmware/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Broadcom. All Rights Reserved.
 
-version: str = "0.14.0.0"
+version: str = "0.14.6.0"
 name: str = "config_modules_vmware"
 author: str = "Broadcom"
 description: str = "VMware Unified Config Modules"

--- a/devops/release/library/version.yml
+++ b/devops/release/library/version.yml
@@ -1,4 +1,4 @@
-user-id: ravi-pratap-s
+user-id: codydouglasBC
 
-version:  0.14.0.0
+version:  0.14.6.0
 

--- a/requirements/prod-requirements.txt
+++ b/requirements/prod-requirements.txt
@@ -1,11 +1,10 @@
 pyVmomi==7.0.3
 
-requests~=2.32.2; python_version>="3.8"
-requests~=2.31.0; python_version<="3.7"
+requests>=2.31.0
 
-pyOpenSSL~=24.1.0
+pyOpenSSL>=23.2.0,<=24.0.0
 
-lxml~=5.2.2
+lxml>=4.9.1,<=5.2.2
 
 # Pinning to old version because of problem with build system dependencies
 #jsonschema~=4.22.0; python_version>="3.8"
@@ -13,4 +12,4 @@ lxml~=5.2.2
 jsonschema~=4.17.3
 
 #some VCF release doesn't have the updated ssl lib required by Urllib3 2.0.x. Urllib3 1.26.19 is validated to work properly
-urllib3~=1.26.19
+urllib3>=1.26.6,<2.0.0

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def _parse_requirements(requirements_file):
 setup(
     name=config_modules_vmware.name,
     # duplicate information due to concourse pipeline requirement
-    version="0.14.0.0",
+    version="0.14.6.0",
     description=config_modules_vmware.description,
     author=config_modules_vmware.author,
     install_requires=_parse_requirements("requirements/prod-requirements.txt"),


### PR DESCRIPTION
Salt requirements were lower and our stricter requirements were causing conflicts on some deployments. Relaxing our dependency version requirements to be compatible. 

All unit tests are passing using the new requirements
![Screenshot 2024-09-06 at 4 52 37 PM](https://github.com/user-attachments/assets/506fc2c2-0da4-4840-98ee-f6ce1ec92ae3)

I also built a .whl and installed it on a testbed and validated the controls with salt. The results were successful. 