### PR TITLE
Release 0.16.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CURRENTLY-IN-DEVELOPMENT
+# `v0.16.0.5`
+### Controller enhancements
+- VCSA Controllers
+    - Add remediation to VCSA control 1216  (vCenter must limit membership to the SystemConfiguration.BashShellAdministrators SSO group.);
+    - Add ignore host exception flag to DVPG controls (dvs_health_check, dvs_network_io_control, dvs_pg_netflow_config,
+      dvpg_promiscuous_mode_policy, dvpg_mac_address_change_policy, dvpg_forged_transmits_policy).
 # `v0.16.0.4`
 ### Controller enhancements
 - VCSA Controllers

--- a/config_modules_vmware/__init__.py
+++ b/config_modules_vmware/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Broadcom. All Rights Reserved.
 
-version: str = "0.16.0.4"
+version: str = "0.16.0.5"
 name: str = "config_modules_vmware"
 author: str = "Broadcom"
 description: str = "VMware Unified Config Modules"

--- a/config_modules_vmware/controllers/vcenter/dv_pg_mac_address_change_policy.py
+++ b/config_modules_vmware/controllers/vcenter/dv_pg_mac_address_change_policy.py
@@ -9,6 +9,7 @@ from pyVmomi import vim  # pylint: disable=E0401
 
 from config_modules_vmware.controllers.base_controller import BaseController
 from config_modules_vmware.controllers.vcenter.utils.vc_dvs_utils import is_host_disconnect_exception
+from config_modules_vmware.controllers.vcenter.utils.vc_dvs_utils import is_host_exception
 from config_modules_vmware.controllers.vcenter.utils.vc_port_group_utils import (
     get_all_non_uplink_non_nsx_port_group_and_security_configs,
 )
@@ -35,6 +36,7 @@ PORT_GROUP_NAME = "port_group_name"
 GLOBAL = "__GLOBAL__"
 OVERRIDES = "__OVERRIDES__"
 IGNORE_DISCONNECTED_HOSTS = "ignore_disconnected_hosts"
+IGNORE_HOST_EXCEPTION = "ignore_host_exception"
 
 
 class DVPortGroupMacAddressChangePolicy(BaseController):
@@ -192,6 +194,7 @@ class DVPortGroupMacAddressChangePolicy(BaseController):
         desired_global_mac_address_change_value = desired_values.get(GLOBAL, {}).get(DESIRED_KEY)
         overrides = desired_values.get(OVERRIDES, [])
         ignore_disconnected_hosts = desired_values.get(IGNORE_DISCONNECTED_HOSTS, False)
+        ignore_host_exception = desired_values.get(IGNORE_HOST_EXCEPTION, False)
         all_dv_port_groups = get_all_non_uplink_non_nsx_port_group_and_security_configs(
             vc_vmomi_client, PortGroupSecurityConfigEnum.MAC_CHANGES
         )
@@ -235,6 +238,9 @@ class DVPortGroupMacAddressChangePolicy(BaseController):
                         logger.debug(f"DVS TASK ERROR: - {task.info.error}")
                         if is_host_disconnect_exception(task.info.error) and ignore_disconnected_hosts:
                             logger.info(f"Ignore disconnected hosts caused exception - {e}")
+                            continue
+                        if is_host_exception(task.info.error) and ignore_host_exception:
+                            logger.info(f"Ignore all host caused exception - {e}")
                             continue
                     logger.exception(f"An error occurred: {e}")
                     errors.append(str(e))

--- a/config_modules_vmware/controllers/vcenter/dv_pg_promiscuous_mode_policy.py
+++ b/config_modules_vmware/controllers/vcenter/dv_pg_promiscuous_mode_policy.py
@@ -9,6 +9,7 @@ from pyVmomi import vim  # pylint: disable=E0401
 
 from config_modules_vmware.controllers.base_controller import BaseController
 from config_modules_vmware.controllers.vcenter.utils.vc_dvs_utils import is_host_disconnect_exception
+from config_modules_vmware.controllers.vcenter.utils.vc_dvs_utils import is_host_exception
 from config_modules_vmware.controllers.vcenter.utils.vc_port_group_utils import (
     get_all_non_uplink_non_nsx_port_group_and_security_configs,
 )
@@ -35,6 +36,7 @@ NSX_BACKING_TYPE = "nsx"
 GLOBAL = "__GLOBAL__"
 OVERRIDES = "__OVERRIDES__"
 IGNORE_DISCONNECTED_HOSTS = "ignore_disconnected_hosts"
+IGNORE_HOST_EXCEPTION = "ignore_host_exception"
 
 
 class DVPortGroupPromiscuousModePolicy(BaseController):
@@ -191,6 +193,7 @@ class DVPortGroupPromiscuousModePolicy(BaseController):
         desired_global_promiscuous_mode_value = desired_values.get(GLOBAL, {}).get(DESIRED_KEY)
         overrides = desired_values.get(OVERRIDES, [])
         ignore_disconnected_hosts = desired_values.get(IGNORE_DISCONNECTED_HOSTS, False)
+        ignore_host_exception = desired_values.get(IGNORE_HOST_EXCEPTION, False)
         non_uplink_non_nsx_dv_pgs = get_all_non_uplink_non_nsx_port_group_and_security_configs(
             vc_vmomi_client, PortGroupSecurityConfigEnum.ALLOW_PROMISCUOUS
         )
@@ -233,6 +236,9 @@ class DVPortGroupPromiscuousModePolicy(BaseController):
                         logger.debug(f"DVS TASK ERROR: - {task.info.error}")
                         if is_host_disconnect_exception(task.info.error) and ignore_disconnected_hosts:
                             logger.info(f"Ignore disconnected hosts caused exception - {e}")
+                            continue
+                        if is_host_exception(task.info.error) and ignore_host_exception:
+                            logger.info(f"Ignore all host caused exception - {e}")
                             continue
                     logger.exception(f"An error occurred: {e}")
                     errors.append(str(e))

--- a/config_modules_vmware/controllers/vcenter/sso_bash_shell_authorized_members_config.py
+++ b/config_modules_vmware/controllers/vcenter/sso_bash_shell_authorized_members_config.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Broadcom. All Rights Reserved.
 import logging
+from collections import defaultdict
 from typing import Any
 from typing import Dict
 from typing import List
@@ -26,6 +27,8 @@ NAME_KEY = "name"
 MEMBER_TYPE_KEY = "member_type"
 MEMBER_TYPE_USER = "USER"
 MEMBER_TYPE_GROUP = "GROUP"
+TO_ADD = "+"
+TO_REMOVE = "-"
 
 
 class SSOBashShellAuthorizedMembersConfig(BaseController):
@@ -49,8 +52,7 @@ class SSOBashShellAuthorizedMembersConfig(BaseController):
         products=[BaseContext.ProductEnum.VCENTER],  # product from enum in BaseContext.
         components=[],  # subcomponent within the product if applicable.
         status=ControllerMetadata.ControllerStatus.ENABLED,  # used to enable/disable a controller
-        impact=ControllerMetadata.RemediationImpact.REMEDIATION_SKIPPED,
-        # from enum in ControllerMetadata.RemediationImpact.
+        impact=None,  # from enum in ControllerMetadata.RemediationImpact.
         scope="",  # any information or limitations about how the controller operates. i.e. runs as a CLI on VCSA.
     )
 
@@ -151,20 +153,113 @@ class SSOBashShellAuthorizedMembersConfig(BaseController):
         )
         return members_in_bash_shell_administrators_group
 
-    def set(self, context: VcenterContext, desired_values: List) -> Tuple[str, List[Any]]:
+    def _normalize(self, item: Dict) -> Dict:
+        """Name and domain are case insensitive, ignore case when do comparison.
+        :param item: dict item of a bash shell authorized member.
+        :type item: Dict
+        :return: dict of normalized item.
+        :rtype: Dict
+        """
+        return {
+            NAME_KEY: item[NAME_KEY].lower(),
+            MEMBER_TYPE_KEY: item[MEMBER_TYPE_KEY],
+            DOMAIN_KEY: item[DOMAIN_KEY].lower(),
+        }
+
+    def _gen_remediate_configs(self, current: List, desired: List) -> Dict:
+        """Compare current and desired bash shell authorized members to generate remediate configs.
+
+        :param current: Current list of bash shell authorized members.
+        :type current: List
+        :param desired: Desired list of bash shell authorized members.
+        :type desired: list
+        :return: Dict of "+"/"-" items for remediation, {} if nothing to add or remove
+        :rtype: Dict
+        """
+
+        logger.debug(f"Current members - {current}, desired members: {desired}")
+        current_set = {tuple(self._normalize(item).values()): item for item in current}
+        desired_set = {tuple(self._normalize(item).values()): item for item in desired}
+        current_keys = set(current_set.keys())
+        desired_keys = set(desired_set.keys())
+        # if item in current but not in desired, to remove.
+        to_remove = [current_set[key] for key in current_keys - desired_keys]
+        # if item in desired but not in current, to add.
+        to_add = [desired_set[key] for key in desired_keys - current_keys]
+        # group operations based on type (user or group).
+        operations = defaultdict(lambda: {TO_ADD: [], TO_REMOVE: []})
+        for item in to_remove:
+            operations[item[MEMBER_TYPE_KEY]][TO_REMOVE].append(item)
+        for item in to_add:
+            operations[item[MEMBER_TYPE_KEY]][TO_ADD].append(item)
+        # return empty if no operation needed.
+        result = {k: v for k, v in operations.items() if v[TO_ADD] or v[TO_REMOVE]}
+        logger.debug(f"Remediate configs - {result}")
+
+        return result
+
+    def set(self, context: VcenterContext, desired_values: Dict) -> Tuple[str, List[Any]]:
         """Remediation has not been implemented for this control. It's possible that a customer may legitimately add
          a new user and forget to update the control accordingly. Remediating the control could lead to the removal
          of these users, with potential unknown implications.
 
         :param context: Product context instance.
         :type context: VcenterContext
-        :param desired_values: List of objects containing users and groups details with name, domain and member_type.
-        :type desired_values: List
+        :param desired_values: Dict of objects containing users and groups details with name, domain and member_type
+                               and operaions to "add" or "remove".
+        :type desired_values: Dict
         :return: Tuple of "status" and list of error messages.
         :rtype: Tuple
         """
-        errors = [consts.REMEDIATION_SKIPPED_MESSAGE]
-        status = RemediateStatus.SKIPPED
+
+        status = RemediateStatus.SUCCESS
+        errors = []
+
+        try:
+            logger.debug(f"Remediation - {desired_values}")
+            vc_vmomi_sso_client = context.vc_vmomi_sso_client()
+
+            # Remediate group members.
+            group_opers = desired_values.get("GROUP", [])
+            if group_opers:
+                logger.debug(f"Group operations - {group_opers}")
+                # Handle remove
+                groups_to_remove = group_opers.get(TO_REMOVE, [])
+                for group_to_remove in groups_to_remove:
+                    logger.debug(f"Removing user - {group_to_remove}")
+                    vc_vmomi_sso_client.remove_from_group(
+                        BASH_SHELL_ADMINISTRATOR_GROUP_KEY, group_to_remove[NAME_KEY], group_to_remove[DOMAIN_KEY]
+                    )
+                # Handle add
+                groups_to_add = group_opers.get(TO_ADD, [])
+                for group_to_add in groups_to_add:
+                    logger.debug(f"Adding group - {group_to_add}")
+                    vc_vmomi_sso_client.add_group_to_group(
+                        BASH_SHELL_ADMINISTRATOR_GROUP_KEY, group_to_add[NAME_KEY], group_to_add[DOMAIN_KEY]
+                    )
+            # Remediate user members.
+            user_opers = desired_values.get("USER", [])
+            if user_opers:
+                logger.debug(f"User operations - {user_opers}")
+                # Handle remove
+                users_to_remove = user_opers.get(TO_REMOVE, [])
+                for user_to_remove in users_to_remove:
+                    logger.debug(f"Removing user - {user_to_remove}")
+                    vc_vmomi_sso_client.remove_from_group(
+                        BASH_SHELL_ADMINISTRATOR_GROUP_KEY, user_to_remove[NAME_KEY], user_to_remove[DOMAIN_KEY]
+                    )
+                # Handle add
+                users_to_add = user_opers.get(TO_ADD, [])
+                for user_to_add in users_to_add:
+                    logger.debug(f"Adding user - {user_to_add}")
+                    vc_vmomi_sso_client.add_user_to_group(
+                        BASH_SHELL_ADMINISTRATOR_GROUP_KEY, user_to_add[NAME_KEY], user_to_add[DOMAIN_KEY]
+                    )
+        except Exception as e:
+            logger.exception(f"An error occurred: {e}")
+            errors.append(str(e))
+            status = RemediateStatus.FAILED
+
         return status, errors
 
     def check_compliance(self, context: VcenterContext, desired_values: Dict) -> Dict:
@@ -190,16 +285,80 @@ class SSOBashShellAuthorizedMembersConfig(BaseController):
             logger.debug(f"User input name patterns to be excluded from compliance check: {exclude_user_patterns}")
             all_member_configs = filter_member_configs(all_member_configs, exclude_user_patterns)
 
-        non_compliant_configs, desired_configs = Comparator.get_non_compliant_configs(
-            all_member_configs, desired_values.get("members", [])
+        desired_members = desired_values.get("members", [])
+        non_compliant_configs, _ = Comparator.get_non_compliant_configs(
+            [self._normalize(item) for item in all_member_configs], [self._normalize(item) for item in desired_members]
         )
 
         if non_compliant_configs:
             result = {
                 consts.STATUS: ComplianceStatus.NON_COMPLIANT,
-                consts.CURRENT: non_compliant_configs,
-                consts.DESIRED: desired_configs,
+                consts.CURRENT: all_member_configs,
+                consts.DESIRED: desired_members,
             }
         else:
             result = {consts.STATUS: ComplianceStatus.COMPLIANT}
         return result
+
+    def remediate(self, context: VcenterContext, desired_values: Dict) -> Dict:
+        """
+        Remediate configuration drifts by applying desired values.
+
+        | Sample desired state
+
+        .. code-block:: json
+
+            {
+              "members": [
+                {
+                  "name": "test-group",
+                  "domain": "vsphere.local",
+                  "member_type": "GROUP",
+                },
+                {
+                  "name": "test-user",
+                  "domain": "vsphere.local",
+                  "member_type": "USER",
+                },
+                {
+                  "name": "ad-ldap-user",
+                  "domain": "adldap.com",
+                  "member_type": "USER",
+                }
+              ],
+              "exclude_user_patterns": [
+                "vmware-applmgmtservice-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+              ]
+            }
+
+        :param context: Product context instance.
+        :type context: VcenterContext
+        :param desired_values: Desired values for sso bash shell authorized members
+        :type desired_values: Dict
+        :return: Dict of status and current/desired value(for non_compliant) or errors (for failure).
+        :rtype: Dict
+        """
+        logger.info("Running remediation for SSO bash shell authorized members")
+        all_member_configs, errors = self.get(context=context)
+
+        if errors:
+            return {consts.STATUS: RemediateStatus.FAILED, consts.ERRORS: errors}
+
+        # check if need to exclude any members.
+        exclude_user_patterns = desired_values.get("exclude_user_patterns", [])
+        if exclude_user_patterns:
+            logger.debug(f"User input name patterns to be excluded from remediation: {exclude_user_patterns}")
+            all_member_configs = filter_member_configs(all_member_configs, exclude_user_patterns)
+
+        remediate_configs = self._gen_remediate_configs(all_member_configs, desired_values.get("members", []))
+        if not remediate_configs:
+            return {consts.STATUS: RemediateStatus.SKIPPED, consts.ERRORS: [consts.CONTROL_ALREADY_COMPLIANT]}
+
+        status, errors = self.set(context, remediate_configs)
+        if not errors:
+            return {
+                consts.STATUS: status,
+                consts.OLD: all_member_configs,
+                consts.NEW: desired_values.get("members", []),
+            }
+        return {consts.STATUS: status, consts.ERRORS: errors}

--- a/config_modules_vmware/controllers/vcenter/users_groups_roles_config.py
+++ b/config_modules_vmware/controllers/vcenter/users_groups_roles_config.py
@@ -57,7 +57,7 @@ class UsersGroupsRolesConfig(BaseController):
         products=[BaseContext.ProductEnum.VCENTER],  # product from enum in BaseContext.
         components=[],  # subcomponent within the product if applicable.
         status=ControllerMetadata.ControllerStatus.ENABLED,  # used to enable/disable a controller
-        impact=ControllerMetadata.RemediationImpact.REMEDIATION_SKIPPED,  # from enum in ControllerMetadata.RemediationImpact.
+        impact=None,  # from enum in ControllerMetadata.RemediationImpact.
         scope="",  # any information or limitations about how the controller operates. i.e. runs as a CLI on VCSA.
     )
 

--- a/config_modules_vmware/controllers/vcenter/utils/vc_dvs_utils.py
+++ b/config_modules_vmware/controllers/vcenter/utils/vc_dvs_utils.py
@@ -17,3 +17,10 @@ def is_host_disconnect_exception(e):
             if not isinstance(hostfault.fault, vmodl.fault.HostNotConnected):
                 return False
     return True
+
+
+def is_host_exception(e):
+    # For any host issue caused exception, return True
+    if e.hostFault:
+        return True
+    return False

--- a/config_modules_vmware/framework/clients/vcenter/vc_vmomi_sso_client.py
+++ b/config_modules_vmware/framework/clients/vcenter/vc_vmomi_sso_client.py
@@ -179,6 +179,60 @@ class VcVmomiSSOClient(object):
         group_info = self.content.principalDiscoveryService.FindGroup(pid)
         return group_info
 
+    def remove_from_group(self, groupname, name, domain) -> None:
+        """
+        Remove a member with name and domain from  the named group.
+
+        :type groupname: 'str'
+        :param groupname: Name of group
+        :type name: 'str'
+        :param name: member (user or group) name
+        :type domain: 'str'
+        :param domain: Domain name
+        :return: None.
+        """
+        logger.debug(f"Remove from group - {groupname}")
+        pid = sso.PrincipalId(name=name, domain=domain)
+        logger.debug(f"Name - {name}, domain - {domain}, principal id - {pid}")
+        self.content.principalManagementService.RemoveFromLocalGroup(pid, groupname)
+        return
+
+    def add_user_to_group(self, groupname, name, domain) -> None:
+        """
+        Add a member with name and domain to  the named group.
+
+        :type groupname: 'str'
+        :param groupname: Name of group
+        :type name: 'str'
+        :param name: member (user or group) name
+        :type domain: 'str'
+        :param domain: Domain name
+        :return: None.
+        """
+        logger.debug(f"Add to group - {groupname}")
+        pid = sso.PrincipalId(name=name, domain=domain)
+        logger.debug(f"Name - {name}, domain - {domain}, principal id - {pid}")
+        self.content.principalManagementService.AddUserToLocalGroup(pid, groupname)
+        return
+
+    def add_group_to_group(self, groupname, name, domain) -> None:
+        """
+        Add a member with name and domain to  the named group.
+
+        :type groupname: 'str'
+        :param groupname: Name of group
+        :type name: 'str'
+        :param name: member (user or group) name
+        :type domain: 'str'
+        :param domain: Domain name
+        :return: None.
+        """
+        logger.debug(f"Add to group - {groupname}")
+        pid = sso.PrincipalId(name=name, domain=domain)
+        logger.debug(f"Name - {name}, domain - {domain}, principal id - {pid}")
+        self.content.principalManagementService.AddGroupToLocalGroup(pid, groupname)
+        return
+
     def get_a_group_id(self, name, domain):
         """
         Creates a user group.

--- a/config_modules_vmware/schemas/compliance_reference_schema.json
+++ b/config_modules_vmware/schemas/compliance_reference_schema.json
@@ -472,7 +472,7 @@
                       "type": "array",
                       "items": {
                         "type": "string",
-                        "description": "User defined patterns to exclude users from compliance check"
+                        "description": "User defined patterns to exclude users (by user or group name) from compliance check"
                       },
                       "minItems": 0
                     }
@@ -735,6 +735,11 @@
                       "type": "boolean",
                       "default": false,
                       "description": "ignore disconnected hosts caused exceptions."
+                    },
+                    "ignore_host_exception": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "ignore all host caused exceptions."
                     }
                   },
                   "minProperties": 1,
@@ -797,6 +802,11 @@
                       "type": "boolean",
                       "default": false,
                       "description": "ignore disconnected hosts caused exceptions."
+                    },
+                    "ignore_host_exception": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "ignore all host caused exceptions."
                     }
                   },
                   "minProperties": 1,
@@ -889,6 +899,11 @@
                       "type": "boolean",
                       "default": false,
                       "description": "ignore disconnected hosts caused exceptions."
+                    },
+                    "ignore_host_exception": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "ignore all host caused exceptions."
                     }
                   },
                   "minProperties": 1,
@@ -950,6 +965,11 @@
                       "type": "boolean",
                       "default": false,
                       "description": "ignore disconnected hosts caused exceptions."
+                    },
+                    "ignore_host_exception": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "ignore all host caused exceptions."
                     }
                   },
                   "minProperties": 1,
@@ -1013,6 +1033,11 @@
                       "type": "boolean",
                       "default": false,
                       "description": "ignore disconnected hosts caused exceptions."
+                    },
+                    "ignore_host_exception": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "ignore all host caused exceptions."
                     }
                   },
                   "minProperties": 1,
@@ -1076,6 +1101,11 @@
                       "type": "boolean",
                       "default": false,
                       "description": "ignore disconnected hosts caused exceptions."
+                    },
+                    "ignore_host_exception": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "ignore all host caused exceptions."
                     }
                   },
                   "minProperties": 1,

--- a/docs/controllers/markdown/vcenter/vcenter.md
+++ b/docs/controllers/markdown/vcenter/vcenter.md
@@ -121,6 +121,7 @@
   * [`SSOBashShellAuthorizedMembersConfig.get()`](vcenter.sso_bash_shell_authorized_members_config.md#vcenter.sso_bash_shell_authorized_members_config.SSOBashShellAuthorizedMembersConfig.get)
   * [`SSOBashShellAuthorizedMembersConfig.set()`](vcenter.sso_bash_shell_authorized_members_config.md#vcenter.sso_bash_shell_authorized_members_config.SSOBashShellAuthorizedMembersConfig.set)
   * [`SSOBashShellAuthorizedMembersConfig.check_compliance()`](vcenter.sso_bash_shell_authorized_members_config.md#vcenter.sso_bash_shell_authorized_members_config.SSOBashShellAuthorizedMembersConfig.check_compliance)
+  * [`SSOBashShellAuthorizedMembersConfig.remediate()`](vcenter.sso_bash_shell_authorized_members_config.md#vcenter.sso_bash_shell_authorized_members_config.SSOBashShellAuthorizedMembersConfig.remediate)
 * [`SSOFailedLoginAttemptInterval`](vcenter.sso_failed_login_attempt_interval.md)
   * [`SSOFailedLoginAttemptInterval.get()`](vcenter.sso_failed_login_attempt_interval.md#vcenter.sso_failed_login_attempt_interval.SSOFailedLoginAttemptInterval.get)
   * [`SSOFailedLoginAttemptInterval.set()`](vcenter.sso_failed_login_attempt_interval.md#vcenter.sso_failed_login_attempt_interval.SSOFailedLoginAttemptInterval.set)

--- a/docs/controllers/markdown/vcenter/vcenter.sso_bash_shell_authorized_members_config.md
+++ b/docs/controllers/markdown/vcenter/vcenter.sso_bash_shell_authorized_members_config.md
@@ -24,7 +24,7 @@ Controller Metadata
   ],
   "components": [],
   "status": "ENABLED",
-  "impact": "REMEDIATION_SKIPPED",
+  "impact": null,
   "scope": "",
   "type": "COMPLIANCE",
   "functional_test_targets": []
@@ -80,7 +80,8 @@ Remediation has not been implemented for this control. It’s possible that a cu
 
 * **Parameters:**
   * **context** (*VcenterContext*) – Product context instance.
-  * **desired_values** (*List*) – List of objects containing users and groups details with name, domain and member_type.
+  * **desired_values** (*Dict*) – Dict of objects containing users and groups details with name, domain and member_type
+    and operaions to “add” or “remove”.
 * **Returns:**
   Tuple of “status” and list of error messages.
 * **Return type:**
@@ -93,6 +94,45 @@ Check compliance of authorized members.
 * **Parameters:**
   * **context** (*VcenterContext*) – Product context instance.
   * **desired_values** (*Dict*) – Desired values for authorized members.
+* **Returns:**
+  Dict of status and current/desired value(for non_compliant) or errors (for failure).
+* **Return type:**
+  Dict
+
+#### remediate(context, desired_values)
+
+Remediate configuration drifts by applying desired values.
+
+Sample desired state
+<br/>
+```json
+{
+  "members": [
+    {
+      "name": "test-group",
+      "domain": "vsphere.local",
+      "member_type": "GROUP",
+    },
+    {
+      "name": "test-user",
+      "domain": "vsphere.local",
+      "member_type": "USER",
+    },
+    {
+      "name": "ad-ldap-user",
+      "domain": "adldap.com",
+      "member_type": "USER",
+    }
+  ],
+  "exclude_user_patterns": [
+    "vmware-applmgmtservice-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+  ]
+}
+```
+
+* **Parameters:**
+  * **context** (*VcenterContext*) – Product context instance.
+  * **desired_values** (*Dict*) – Desired values for sso bash shell authorized members
 * **Returns:**
   Dict of status and current/desired value(for non_compliant) or errors (for failure).
 * **Return type:**

--- a/docs/controllers/markdown/vcenter/vcenter.users_groups_roles_config.md
+++ b/docs/controllers/markdown/vcenter/vcenter.users_groups_roles_config.md
@@ -21,7 +21,7 @@ Controller Metadata
   ],
   "components": [],
   "status": "ENABLED",
-  "impact": "REMEDIATION_SKIPPED",
+  "impact": null,
   "scope": "",
   "type": "COMPLIANCE",
   "functional_test_targets": []


### PR DESCRIPTION
Release 0.16.0.5

Controller enhancements
- VCSA Controllers
    - Add remediation to VCSA control 1216  (vCenter must limit membership to the SystemConfiguration.BashShellAdministrators SSO group.);
    - Add ignore host exception flag to DVPG controls (dvs_health_check, dvs_network_io_control, dvs_pg_netflow_config,
      dvpg_promiscuous_mode_policy, dvpg_mac_address_change_policy, dvpg_forged_transmits_policy).